### PR TITLE
Use uint64 for resources to keep consistency with runtime-spec

### DIFF
--- a/libcontainer/cgroups/fs/apply_raw.go
+++ b/libcontainer/cgroups/fs/apply_raw.go
@@ -348,8 +348,8 @@ func removePath(p string, err error) error {
 	return nil
 }
 
-func CheckCpushares(path string, c int64) error {
-	var cpuShares int64
+func CheckCpushares(path string, c uint64) error {
+	var cpuShares uint64
 
 	if c == 0 {
 		return nil

--- a/libcontainer/cgroups/fs/cpu.go
+++ b/libcontainer/cgroups/fs/cpu.go
@@ -55,12 +55,12 @@ func (s *CpuGroup) ApplyDir(path string, cgroup *configs.Cgroup, pid int) error 
 
 func (s *CpuGroup) SetRtSched(path string, cgroup *configs.Cgroup) error {
 	if cgroup.Resources.CpuRtPeriod != 0 {
-		if err := writeFile(path, "cpu.rt_period_us", strconv.FormatInt(cgroup.Resources.CpuRtPeriod, 10)); err != nil {
+		if err := writeFile(path, "cpu.rt_period_us", strconv.FormatUint(cgroup.Resources.CpuRtPeriod, 10)); err != nil {
 			return err
 		}
 	}
 	if cgroup.Resources.CpuRtRuntime != 0 {
-		if err := writeFile(path, "cpu.rt_runtime_us", strconv.FormatInt(cgroup.Resources.CpuRtRuntime, 10)); err != nil {
+		if err := writeFile(path, "cpu.rt_runtime_us", strconv.FormatUint(cgroup.Resources.CpuRtRuntime, 10)); err != nil {
 			return err
 		}
 	}
@@ -69,17 +69,17 @@ func (s *CpuGroup) SetRtSched(path string, cgroup *configs.Cgroup) error {
 
 func (s *CpuGroup) Set(path string, cgroup *configs.Cgroup) error {
 	if cgroup.Resources.CpuShares != 0 {
-		if err := writeFile(path, "cpu.shares", strconv.FormatInt(cgroup.Resources.CpuShares, 10)); err != nil {
+		if err := writeFile(path, "cpu.shares", strconv.FormatUint(cgroup.Resources.CpuShares, 10)); err != nil {
 			return err
 		}
 	}
 	if cgroup.Resources.CpuPeriod != 0 {
-		if err := writeFile(path, "cpu.cfs_period_us", strconv.FormatInt(cgroup.Resources.CpuPeriod, 10)); err != nil {
+		if err := writeFile(path, "cpu.cfs_period_us", strconv.FormatUint(cgroup.Resources.CpuPeriod, 10)); err != nil {
 			return err
 		}
 	}
 	if cgroup.Resources.CpuQuota != 0 {
-		if err := writeFile(path, "cpu.cfs_quota_us", strconv.FormatInt(cgroup.Resources.CpuQuota, 10)); err != nil {
+		if err := writeFile(path, "cpu.cfs_quota_us", strconv.FormatUint(cgroup.Resources.CpuQuota, 10)); err != nil {
 			return err
 		}
 	}

--- a/libcontainer/cgroups/fs/memory.go
+++ b/libcontainer/cgroups/fs/memory.go
@@ -63,14 +63,14 @@ func EnableKernelMemoryAccounting(path string) error {
 	// until a limit is set on the cgroup and limit cannot be set once the
 	// cgroup has children, or if there are already tasks in the cgroup.
 	for _, i := range []int64{1, -1} {
-		if err := setKernelMemory(path, i); err != nil {
+		if err := setKernelMemory(path, uint64(i)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func setKernelMemory(path string, kernelMemoryLimit int64) error {
+func setKernelMemory(path string, kernelMemoryLimit uint64) error {
 	if path == "" {
 		return fmt.Errorf("no such directory for %s", cgroupKernelMemoryLimit)
 	}
@@ -78,7 +78,7 @@ func setKernelMemory(path string, kernelMemoryLimit int64) error {
 		// kernel memory is not enabled on the system so we should do nothing
 		return nil
 	}
-	if err := ioutil.WriteFile(filepath.Join(path, cgroupKernelMemoryLimit), []byte(strconv.FormatInt(kernelMemoryLimit, 10)), 0700); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(path, cgroupKernelMemoryLimit), []byte(strconv.FormatUint(kernelMemoryLimit, 10)), 0700); err != nil {
 		// Check if the error number returned by the syscall is "EBUSY"
 		// The EBUSY signal is returned on attempts to write to the
 		// memory.kmem.limit_in_bytes file if the cgroup has children or
@@ -108,28 +108,28 @@ func setMemoryAndSwap(path string, cgroup *configs.Cgroup) error {
 		// for memory and swap memory, so it won't fail because the new
 		// value and the old value don't fit kernel's validation.
 		if memoryUsage.Limit < uint64(cgroup.Resources.MemorySwap) {
-			if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(cgroup.Resources.MemorySwap, 10)); err != nil {
+			if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatUint(cgroup.Resources.MemorySwap, 10)); err != nil {
 				return err
 			}
-			if err := writeFile(path, "memory.limit_in_bytes", strconv.FormatInt(cgroup.Resources.Memory, 10)); err != nil {
+			if err := writeFile(path, "memory.limit_in_bytes", strconv.FormatUint(cgroup.Resources.Memory, 10)); err != nil {
 				return err
 			}
 		} else {
-			if err := writeFile(path, "memory.limit_in_bytes", strconv.FormatInt(cgroup.Resources.Memory, 10)); err != nil {
+			if err := writeFile(path, "memory.limit_in_bytes", strconv.FormatUint(cgroup.Resources.Memory, 10)); err != nil {
 				return err
 			}
-			if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(cgroup.Resources.MemorySwap, 10)); err != nil {
+			if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatUint(cgroup.Resources.MemorySwap, 10)); err != nil {
 				return err
 			}
 		}
 	} else {
 		if cgroup.Resources.Memory != 0 {
-			if err := writeFile(path, "memory.limit_in_bytes", strconv.FormatInt(cgroup.Resources.Memory, 10)); err != nil {
+			if err := writeFile(path, "memory.limit_in_bytes", strconv.FormatUint(cgroup.Resources.Memory, 10)); err != nil {
 				return err
 			}
 		}
 		if cgroup.Resources.MemorySwap > 0 {
-			if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(cgroup.Resources.MemorySwap, 10)); err != nil {
+			if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatUint(cgroup.Resources.MemorySwap, 10)); err != nil {
 				return err
 			}
 		}
@@ -150,13 +150,13 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 	}
 
 	if cgroup.Resources.MemoryReservation != 0 {
-		if err := writeFile(path, "memory.soft_limit_in_bytes", strconv.FormatInt(cgroup.Resources.MemoryReservation, 10)); err != nil {
+		if err := writeFile(path, "memory.soft_limit_in_bytes", strconv.FormatUint(cgroup.Resources.MemoryReservation, 10)); err != nil {
 			return err
 		}
 	}
 
 	if cgroup.Resources.KernelMemoryTCP != 0 {
-		if err := writeFile(path, "memory.kmem.tcp.limit_in_bytes", strconv.FormatInt(cgroup.Resources.KernelMemoryTCP, 10)); err != nil {
+		if err := writeFile(path, "memory.kmem.tcp.limit_in_bytes", strconv.FormatUint(cgroup.Resources.KernelMemoryTCP, 10)); err != nil {
 			return err
 		}
 	}
@@ -167,12 +167,12 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 	}
 	if cgroup.Resources.MemorySwappiness == nil || int64(*cgroup.Resources.MemorySwappiness) == -1 {
 		return nil
-	} else if int64(*cgroup.Resources.MemorySwappiness) >= 0 && int64(*cgroup.Resources.MemorySwappiness) <= 100 {
-		if err := writeFile(path, "memory.swappiness", strconv.FormatInt(*cgroup.Resources.MemorySwappiness, 10)); err != nil {
+	} else if *cgroup.Resources.MemorySwappiness <= 100 {
+		if err := writeFile(path, "memory.swappiness", strconv.FormatUint(*cgroup.Resources.MemorySwappiness, 10)); err != nil {
 			return err
 		}
 	} else {
-		return fmt.Errorf("invalid value:%d. valid memory swappiness range is 0-100", int64(*cgroup.Resources.MemorySwappiness))
+		return fmt.Errorf("invalid value:%d. valid memory swappiness range is 0-100", *cgroup.Resources.MemorySwappiness)
 	}
 
 	return nil
@@ -234,7 +234,7 @@ func memoryAssigned(cgroup *configs.Cgroup) bool {
 		cgroup.Resources.KernelMemory > 0 ||
 		cgroup.Resources.KernelMemoryTCP > 0 ||
 		cgroup.Resources.OomKillDisable ||
-		(cgroup.Resources.MemorySwappiness != nil && *cgroup.Resources.MemorySwappiness != -1)
+		(cgroup.Resources.MemorySwappiness != nil && int64(*cgroup.Resources.MemorySwappiness) != -1)
 }
 
 func getMemoryData(path, name string) (cgroups.MemoryData, error) {

--- a/libcontainer/cgroups/fs/memory_test.go
+++ b/libcontainer/cgroups/fs/memory_test.go
@@ -276,7 +276,7 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 	defer helper.cleanup()
 
 	swappinessBefore := 60 //default is 60
-	swappinessAfter := int64(0)
+	swappinessAfter := uint64(0)
 
 	helper.writeFileContents(map[string]string{
 		"memory.swappiness": strconv.Itoa(swappinessBefore),
@@ -292,7 +292,7 @@ func TestMemorySetMemorySwappinessDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to parse memory.swappiness - %s", err)
 	}
-	if int64(value) != swappinessAfter {
+	if value != swappinessAfter {
 		t.Fatalf("Got the wrong value (%d), set memory.swappiness = %d failed.", value, swappinessAfter)
 	}
 }

--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -11,13 +11,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	systemdDbus "github.com/coreos/go-systemd/dbus"
 	systemdUtil "github.com/coreos/go-systemd/util"
 	"github.com/godbus/dbus"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
-	"github.com/Sirupsen/logrus"
 )
 
 type Manager struct {
@@ -285,7 +285,7 @@ func (m *Manager) Apply(pid int) error {
 
 	if c.Resources.Memory != 0 {
 		properties = append(properties,
-			newProp("MemoryLimit", uint64(c.Resources.Memory)))
+			newProp("MemoryLimit", c.Resources.Memory))
 	}
 
 	if c.Resources.CpuShares != 0 {
@@ -295,7 +295,7 @@ func (m *Manager) Apply(pid int) error {
 
 	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
 	if c.Resources.CpuQuota != 0 && c.Resources.CpuPeriod != 0 {
-		cpuQuotaPerSecUSec := c.Resources.CpuQuota*1000000 / c.Resources.CpuPeriod
+		cpuQuotaPerSecUSec := uint64(c.Resources.CpuQuota*1000000) / c.Resources.CpuPeriod
 		// systemd converts CPUQuotaPerSecUSec (microseconds per CPU second) to CPUQuota
 		// (integer percentage of CPU) internally.  This means that if a fractional percent of
 		// CPU is indicated by Resources.CpuQuota, we need to round up to the nearest

--- a/libcontainer/configs/cgroup_unix.go
+++ b/libcontainer/configs/cgroup_unix.go
@@ -45,34 +45,34 @@ type Resources struct {
 	Devices []*Device `json:"devices"`
 
 	// Memory limit (in bytes)
-	Memory int64 `json:"memory"`
+	Memory uint64 `json:"memory"`
 
 	// Memory reservation or soft_limit (in bytes)
-	MemoryReservation int64 `json:"memory_reservation"`
+	MemoryReservation uint64 `json:"memory_reservation"`
 
 	// Total memory usage (memory + swap); set `-1` to enable unlimited swap
-	MemorySwap int64 `json:"memory_swap"`
+	MemorySwap uint64 `json:"memory_swap"`
 
 	// Kernel memory limit (in bytes)
-	KernelMemory int64 `json:"kernel_memory"`
+	KernelMemory uint64 `json:"kernel_memory"`
 
 	// Kernel memory limit for TCP use (in bytes)
-	KernelMemoryTCP int64 `json:"kernel_memory_tcp"`
+	KernelMemoryTCP uint64 `json:"kernel_memory_tcp"`
 
 	// CPU shares (relative weight vs. other containers)
-	CpuShares int64 `json:"cpu_shares"`
+	CpuShares uint64 `json:"cpu_shares"`
 
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
-	CpuQuota int64 `json:"cpu_quota"`
+	CpuQuota uint64 `json:"cpu_quota"`
 
 	// CPU period to be used for hardcapping (in usecs). 0 to use system default.
-	CpuPeriod int64 `json:"cpu_period"`
+	CpuPeriod uint64 `json:"cpu_period"`
 
 	// How many time CPU will use in realtime scheduling (in usecs).
-	CpuRtRuntime int64 `json:"cpu_rt_quota"`
+	CpuRtRuntime uint64 `json:"cpu_rt_quota"`
 
 	// CPU period to be used for realtime scheduling (in usecs).
-	CpuRtPeriod int64 `json:"cpu_rt_period"`
+	CpuRtPeriod uint64 `json:"cpu_rt_period"`
 
 	// CPU to use
 	CpusetCpus string `json:"cpuset_cpus"`
@@ -114,7 +114,7 @@ type Resources struct {
 	OomKillDisable bool `json:"oom_kill_disable"`
 
 	// Tuning swappiness behaviour per cgroup
-	MemorySwappiness *int64 `json:"memory_swappiness"`
+	MemorySwappiness *uint64 `json:"memory_swappiness"`
 
 	// Set priority of network traffic for container
 	NetPrioIfpriomap []*IfPrioMap `json:"net_prio_ifpriomap"`

--- a/libcontainer/specconv/spec_linux.go
+++ b/libcontainer/specconv/spec_linux.go
@@ -335,40 +335,39 @@ func createCgroupConfig(name string, useSystemdCgroup bool, spec *specs.Spec) (*
 	c.Resources.Devices = append(c.Resources.Devices, allowedDevices...)
 	if r.Memory != nil {
 		if r.Memory.Limit != nil {
-			c.Resources.Memory = int64(*r.Memory.Limit)
+			c.Resources.Memory = *r.Memory.Limit
 		}
 		if r.Memory.Reservation != nil {
-			c.Resources.MemoryReservation = int64(*r.Memory.Reservation)
+			c.Resources.MemoryReservation = *r.Memory.Reservation
 		}
 		if r.Memory.Swap != nil {
-			c.Resources.MemorySwap = int64(*r.Memory.Swap)
+			c.Resources.MemorySwap = *r.Memory.Swap
 		}
 		if r.Memory.Kernel != nil {
-			c.Resources.KernelMemory = int64(*r.Memory.Kernel)
+			c.Resources.KernelMemory = *r.Memory.Kernel
 		}
 		if r.Memory.KernelTCP != nil {
-			c.Resources.KernelMemoryTCP = int64(*r.Memory.KernelTCP)
+			c.Resources.KernelMemoryTCP = *r.Memory.KernelTCP
 		}
 		if r.Memory.Swappiness != nil {
-			swappiness := int64(*r.Memory.Swappiness)
-			c.Resources.MemorySwappiness = &swappiness
+			c.Resources.MemorySwappiness = r.Memory.Swappiness
 		}
 	}
 	if r.CPU != nil {
 		if r.CPU.Shares != nil {
-			c.Resources.CpuShares = int64(*r.CPU.Shares)
+			c.Resources.CpuShares = *r.CPU.Shares
 		}
 		if r.CPU.Quota != nil {
-			c.Resources.CpuQuota = int64(*r.CPU.Quota)
+			c.Resources.CpuQuota = *r.CPU.Quota
 		}
 		if r.CPU.Period != nil {
-			c.Resources.CpuPeriod = int64(*r.CPU.Period)
+			c.Resources.CpuPeriod = *r.CPU.Period
 		}
 		if r.CPU.RealtimeRuntime != nil {
-			c.Resources.CpuRtRuntime = int64(*r.CPU.RealtimeRuntime)
+			c.Resources.CpuRtRuntime = *r.CPU.RealtimeRuntime
 		}
 		if r.CPU.RealtimePeriod != nil {
-			c.Resources.CpuRtPeriod = int64(*r.CPU.RealtimePeriod)
+			c.Resources.CpuRtPeriod = *r.CPU.RealtimePeriod
 		}
 		if r.CPU.Cpus != nil {
 			c.Resources.CpusetCpus = *r.CPU.Cpus

--- a/update.go
+++ b/update.go
@@ -208,18 +208,18 @@ other options are ignored.
 
 		// Update the value
 		config.Cgroups.Resources.BlkioWeight = *r.BlockIO.Weight
-		config.Cgroups.Resources.CpuPeriod = int64(*r.CPU.Period)
-		config.Cgroups.Resources.CpuQuota = int64(*r.CPU.Quota)
-		config.Cgroups.Resources.CpuShares = int64(*r.CPU.Shares)
-		config.Cgroups.Resources.CpuRtPeriod = int64(*r.CPU.RealtimePeriod)
-		config.Cgroups.Resources.CpuRtRuntime = int64(*r.CPU.RealtimeRuntime)
+		config.Cgroups.Resources.CpuPeriod = *r.CPU.Period
+		config.Cgroups.Resources.CpuQuota = *r.CPU.Quota
+		config.Cgroups.Resources.CpuShares = *r.CPU.Shares
+		config.Cgroups.Resources.CpuRtPeriod = *r.CPU.RealtimePeriod
+		config.Cgroups.Resources.CpuRtRuntime = *r.CPU.RealtimeRuntime
 		config.Cgroups.Resources.CpusetCpus = *r.CPU.Cpus
 		config.Cgroups.Resources.CpusetMems = *r.CPU.Mems
-		config.Cgroups.Resources.KernelMemory = int64(*r.Memory.Kernel)
-		config.Cgroups.Resources.KernelMemoryTCP = int64(*r.Memory.KernelTCP)
-		config.Cgroups.Resources.Memory = int64(*r.Memory.Limit)
-		config.Cgroups.Resources.MemoryReservation = int64(*r.Memory.Reservation)
-		config.Cgroups.Resources.MemorySwap = int64(*r.Memory.Swap)
+		config.Cgroups.Resources.KernelMemory = *r.Memory.Kernel
+		config.Cgroups.Resources.KernelMemoryTCP = *r.Memory.KernelTCP
+		config.Cgroups.Resources.Memory = *r.Memory.Limit
+		config.Cgroups.Resources.MemoryReservation = *r.Memory.Reservation
+		config.Cgroups.Resources.MemorySwap = *r.Memory.Swap
 
 		if err := container.Set(config); err != nil {
 			return err


### PR DESCRIPTION
This is a backport of opencontainers/runc#1375 and it fixes https://github.com/kubernetes/kubernetes/issues/61474#issuecomment-383748728 but please note there were some follow ups to that commit in upstream runc, not sure if those should be considered here as well...

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>

(cherry-picked from commit 8430cc4f488f1925df01e517358c2a4cce8de176)
Signed-off-by: Filipe Brandenburger <filbranden@google.com>