### PR TITLE
BACKPORT: kill.go: Remove unnecessary checks

### DIFF
--- a/kill.go
+++ b/kill.go
@@ -93,13 +93,7 @@ signal to the init process of the "ubuntu01" container:
 func parseSignal(rawSignal string) (syscall.Signal, error) {
 	s, err := strconv.Atoi(rawSignal)
 	if err == nil {
-		sig := syscall.Signal(s)
-		for _, msig := range signalMap {
-			if sig == msig {
-				return sig, nil
-			}
-		}
-		return -1, fmt.Errorf("unknown signal %q", rawSignal)
+		return syscall.Signal(s), nil
 	}
 	signal, ok := signalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
 	if !ok {


### PR DESCRIPTION
Hello, maintainers.

Graceful shutdown and kill with SIGRTMIN..SIGRTMAX don't work when we run systemd in docker container.
This upstream patch fix it, so I want to backport it rhel's docker repo.(Fixes: https://github.com/projectatomic/runc/issues/16)

For more info: 
* https://github.com/opencontainers/runc/pull/1706
* https://github.com/moby/moby/issues/36219


upstream commit: https://github.com/opencontainers/runc/commit/7ac503d1a2135dcf985677a0f8ea6950d9935e9e

... that prevent sending signals not mentioned in signal map.
Currently these are SIGRTMIN..SIGRTMAX.

Signed-off-by: Valentin Kulesh <valentin.kulesh@virtuozzo.com>
Signed-off-by: Wang Long <wanglong19@meituan.com>