### PR TITLE
systemd: Set CollectMode to "inactive-or-failed" for GC

### DIFF
--- a/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/libcontainer/cgroups/systemd/apply_systemd.go
@@ -130,6 +130,8 @@ func (m *Manager) Apply(pid int) error {
 		properties = append(properties, newProp("PIDs", []uint32{uint32(pid)}))
 	}
 
+	properties = append(properties, newProp("CollectMode", "inactive-or-failed"))
+
 	// This is only supported on systemd versions 218 and above.
 	properties = append(properties, newProp("Delegate", true))
 


### PR DESCRIPTION
If a container is killed  then systemd
keeps the scope around unless explicitly removed.

Enabling this setting makes systemd remove the scopes
even for failed scopes so they don't start piling up
eventually slowing down the node.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>