### PR TITLE
[4.5] libctr/init_linux: reorder chdir

### DIFF
--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -126,12 +126,6 @@ func finalizeNamespace(config *initConfig) error {
 		return errors.Wrap(err, "close exec fds")
 	}
 
-	if config.Cwd != "" {
-		if err := unix.Chdir(config.Cwd); err != nil {
-			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %v", config.Cwd, err)
-		}
-	}
-
 	capabilities := &configs.Capabilities{}
 	if config.Capabilities != nil {
 		capabilities = config.Capabilities
@@ -152,6 +146,14 @@ func finalizeNamespace(config *initConfig) error {
 	}
 	if err := setupUser(config); err != nil {
 		return errors.Wrap(err, "setup user")
+	}
+	// Change working directory AFTER the user has been set up.
+	// Otherwise, if the cwd is also a volume that's been chowned to the container user (and not the user running runc),
+	// this command will EPERM.
+	if config.Cwd != "" {
+		if err := unix.Chdir(config.Cwd); err != nil {
+			return fmt.Errorf("chdir to cwd (%q) set in config.json failed: %v", config.Cwd, err)
+		}
 	}
 	if err := system.ClearKeepCaps(); err != nil {
 		return errors.Wrap(err, "clear keep caps")


### PR DESCRIPTION
commit 5e0e67d76cc99d76c8228d48f38f37034503f315 moved the chdir to be one of the
first steps of finalizing the namespace of the container.

However, this causes issues when the cwd is not accessible by the user running runc, but rather
as the container user.

Thus, setupUser has to happen before we call chdir. setupUser still happens before setting the caps,
so the user should be privileged enough to mitigate the issues fixed in 5e0e67d76cc99d76c8228d48f38f37034503f315

Signed-off-by: Peter Hunt <pehunt@redhat.com>