### PR TITLE
[4.8] ci/gha: bump go 1.16-rc1 -> 1.16.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.0-rc1]
+        go-version: [1.14.x, 1.15.x, 1.16.x]
         rootless: ["rootless", ""]
 
     steps:


### PR DESCRIPTION
As the final go 1.16 is released, rc1 is no longer available.

This fixes CI.