### PR TITLE
[4.8] fsmanager.GetStats performance regression

### DIFF
--- a/libcontainer/cgroups/fscommon/open.go
+++ b/libcontainer/cgroups/fscommon/open.go
@@ -71,11 +71,11 @@ func OpenFile(dir, file string, flags int) (*os.File, error) {
 		flags |= os.O_TRUNC | os.O_CREATE
 		mode = 0o600
 	}
-	reldir := strings.TrimPrefix(dir, cgroupfsPrefix)
-	if len(reldir) == len(dir) { // non-standard path, old system?
+	if prepareOpenat2() != nil {
 		return openWithSecureJoin(dir, file, flags, mode)
 	}
-	if prepareOpenat2() != nil {
+	reldir := strings.TrimPrefix(dir, cgroupfsPrefix)
+	if len(reldir) == len(dir) { // non-standard path, old system?
 		return openWithSecureJoin(dir, file, flags, mode)
 	}
 


### PR DESCRIPTION
This is a backport of https://github.com/opencontainers/runc/pull/2921 (modulo benchmark code). Original description follows.

----- 

Commit 88e8350de28 (PR #2169), among the other things, replaced filepath.Join with
securejoin.SecureJoin for both reads and writes to cgroupfs.
    
Commits e76ac1c054 and 31f0f5b7e03a (PR #2604) switched more code to use
`fscommon.ReadFile` (and thus `securejoin`). Commit 0228226e6d (PR #2635) introduced
`fscommon.OpenFile` (which uses `securejoin` as a fallback if `openat2(2)` is not available,
which is the case for older kernels), and commit c95e69007c4 (PR #2635) switched
most of cgroup/fs[2] code to use it.
    
As a result, `fs.GetStats()` method became noticeable slower, mostly due
to securejoin calling `os.Lstat` and `filepath.Clean`.
    
Using securejoin as a security measure while reading cgroupfs files is
not very well justified, as cgroupfs do not contain symlinks, and none of the
GetStats code have uncleaned paths.
    
This PR modifies the code to not use securejoin in case the file is
to be opened read-only, and introduces a benchmark to measure
the different.
    
Using the added `BenchmarkGetStats` on a CentOS 8 VM, I see the following
improvement:
    
Before (the last commit):
```
BenchmarkGetStats-8               8376            625135 ns/op
```
After:
```
BenchmarkGetStats-8              13162            452281 ns/op
```
